### PR TITLE
Add image name and tag to kaniko builds

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -49,6 +49,12 @@ type PushOptions struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
+type KanikoParams struct {
+	// +optional
+	// Kaniko image tag to use when creating the build Job
+	Tag string `json:"tag,omitempty"`
+}
+
 type Build struct {
 	// +optional
 	// BuildArgs is an array of build variables that are provided to the image building backend.
@@ -69,6 +75,10 @@ type Build struct {
 	// Those secrets should be used for private resources such as a private Github repo.
 	// For container registries auth use module.spec.imagePullSecret instead.
 	Secrets []v1.LocalObjectReference `json:"secrets"`
+
+	// +optional
+	// KanikoParams is used to customize the building process of the image.
+	KanikoParams *KanikoParams `json:"kanikoParams,omitempty"`
 }
 
 // KernelMapping pairs kernel versions with a DriverContainer image.

--- a/ci/module-kmm-ci-build.template.yaml
+++ b/ci/module-kmm-ci-build.template.yaml
@@ -32,5 +32,9 @@ spec:
               RUN echo $CI_BUILD_ARG > /build-arg
               RUN echo $KERNEL_VERSION > /kernel-version
               RUN echo $WITH_DEFAULT_VALUE > /default-value
+
+            # Optional. If kanikoParams.tag is empty, the default value will be: 'latest'
+            kanikoParams:
+              tag: "debug"
   selector:
     kubernetes.io/hostname: minikube

--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -1869,6 +1869,15 @@ spec:
                             type: array
                           dockerfile:
                             type: string
+                          kanikoParams:
+                            description: KanikoParams is used to customize the building
+                              process of the image.
+                            properties:
+                              tag:
+                                description: Kaniko image tag to use when creating
+                                  the build Job
+                                type: string
+                            type: object
                           pull:
                             description: Pull contains settings determining how to
                               check if the DriverContainer image already exists.
@@ -1957,6 +1966,15 @@ spec:
                                   type: array
                                 dockerfile:
                                   type: string
+                                kanikoParams:
+                                  description: KanikoParams is used to customize the
+                                    building process of the image.
+                                  properties:
+                                    tag:
+                                      description: Kaniko image tag to use when creating
+                                        the build Job
+                                      type: string
+                                  type: object
                                 pull:
                                   description: Pull contains settings determining
                                     how to check if the DriverContainer image already

--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -92,6 +92,11 @@ func (m *maker) MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, ta
 	volumes = append(volumes, makeBuildSecretVolumes(buildConfig.Secrets)...)
 	volumeMounts = append(volumeMounts, makeBuildSecretVolumeMounts(buildConfig.Secrets)...)
 
+	kanikoImageTag := "latest"
+	if buildConfig.KanikoParams != nil && buildConfig.KanikoParams.Tag != "" {
+		kanikoImageTag = buildConfig.KanikoParams.Tag
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mod.Name + "-build-",
@@ -109,7 +114,7 @@ func (m *maker) MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, ta
 						{
 							Args:         args,
 							Name:         "kaniko",
-							Image:        "gcr.io/kaniko-project/executor:latest",
+							Image:        "gcr.io/kaniko-project/executor:" + kanikoImageTag,
 							VolumeMounts: volumeMounts,
 						},
 					},

--- a/internal/build/job/maker_test.go
+++ b/internal/build/job/maker_test.go
@@ -271,4 +271,26 @@ var _ = Describe("MakeJob", func() {
 			false,
 		),
 	)
+
+	Describe("should override kaniko image tag", func() {
+		It("use a custom given tag", func() {
+			const customTag = "some-tag"
+
+			km := kmmv1beta1.KernelMapping{
+				Build: &kmmv1beta1.Build{
+					BuildArgs:    buildArgs,
+					Dockerfile:   dockerfile,
+					KanikoParams: &kmmv1beta1.KanikoParams{Tag: customTag},
+				},
+				ContainerImage: containerImage,
+			}
+
+			override := kmmv1beta1.BuildArg{Name: "KERNEL_VERSION", Value: kernelVersion}
+			mh.EXPECT().ApplyBuildArgOverrides(buildArgs, override)
+
+			actual, err := m.MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual.Spec.Template.Spec.Containers[0].Image).To(Equal("gcr.io/kaniko-project/executor:" + customTag))
+		})
+	})
 })


### PR DESCRIPTION
Allow the user to configure which image and tag
from kaniko want to use for the building process.

MGMT-11383